### PR TITLE
fix link double definition issues

### DIFF
--- a/TextTable.h
+++ b/TextTable.h
@@ -127,7 +127,7 @@ class TextTable {
     }
 };
 
-std::ostream & operator<<( std::ostream & stream, TextTable const & table )
+inline std::ostream & operator<<( std::ostream & stream, TextTable const & table )
 {
     table.setup();
     stream << table.ruler() << "\n";


### PR DESCRIPTION
make function in header inline

Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>