### PR TITLE
Allow for correct computations of glyph length for utf8 encoded multi…

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
-#undef TEXTTABLE_ENCODE_MULTIBYTE_STRINGS
-#undef TEXTTABLE_USE_EN_US_UTF8
+#define TEXTTABLE_ENCODE_MULTIBYTE_STRINGS
+#define TEXTTABLE_USE_EN_US_UTF8
 
 #include "TextTable.h"
 

--- a/example.cpp
+++ b/example.cpp
@@ -1,4 +1,8 @@
 #include <iostream>
+
+#undef TEXTTABLE_ENCODE_MULTIBYTE_STRINGS
+#undef TEXTTABLE_USE_EN_US_UTF8
+
 #include "TextTable.h"
 
 int main()
@@ -25,7 +29,7 @@ int main()
     t.add( "3001" );
     t.endOfRow();
 
-    t.add( "Bob" );
+    t.add( "Bob Çuçşü" );
     t.add( "male" );
     t.add( "25" );
     t.endOfRow();


### PR DESCRIPTION
…byte characters.

This leads to a correct table even for multibyte characters.
Feature needs to be enabled with a preprocessor variable.